### PR TITLE
When exporting to binary, do it on retrained model with full dataset.

### DIFF
--- a/models/MLmodels/DecisionTree.py
+++ b/models/MLmodels/DecisionTree.py
@@ -100,16 +100,26 @@ class DecisionTree:
 
     def save_the_trained_model(self):
         # save the model to disk
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_DecisionTree_model.sav'
-        pickle.dump(self.DecisionTreeM, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         # save the model to disk
+        self.DecisionTreeM = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_DecisionTree_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
     def get_trained_model(self):
         return self.DecisionTreeM
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, self.data.Y)
+
 
 
 # Example working scenarios:

--- a/models/MLmodels/ElasticNets.py
+++ b/models/MLmodels/ElasticNets.py
@@ -100,16 +100,26 @@ class ElasticNet:
 
     def save_the_trained_model(self):
         # save the model to disk
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_ElasticNet_model.sav'
-        pickle.dump(self.eNet, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         # save the model to disk
+        self.eNet = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_ElasticNet_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
     def get_trained_model(self):
         return self.eNet
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, self.data.Y)
+
 
 
 #ElasticNet().regression_and_plot_curves()

--- a/models/MLmodels/Lasso.py
+++ b/models/MLmodels/Lasso.py
@@ -100,16 +100,26 @@ class Lasso:
 
     def save_the_trained_model(self):
         # save the model to disk
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_Lasso_model.sav'
-        pickle.dump(self.lasso, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         # save the model to disk
+        self.lasso = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_Lasso_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
     def get_trained_model(self):
         return self.lasso
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, self.data.Y)
+
 
 
 

--- a/models/MLmodels/LinearRegression.py
+++ b/models/MLmodels/LinearRegression.py
@@ -106,14 +106,16 @@ class LinearRegression:
         Saves the trained machine learning model to binary file in current
         working diractory.
         """
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_LinearRegression_model.sav'
-        pickle.dump(self.model, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         """
         Saves the wrapper class including the trained machine learning model to binary file
         in current working directory.
         """
+        self.model = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_LinearRegression_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
@@ -122,3 +124,12 @@ class LinearRegression:
         Returns the trained machine learning model.
         """
         return self.model
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, self.data.Y)
+
+

--- a/models/MLmodels/NeuralNetwork.py
+++ b/models/MLmodels/NeuralNetwork.py
@@ -122,16 +122,26 @@ class NeuralNetwork:
 
     def save_the_trained_model(self):
         # save the model to disk
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_Lasso_model.sav'
-        pickle.dump(self.nn, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         # save the model to disk
+        self.nn = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_NeuralNetwork_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
     def get_trained_model(self):
         return self.nn
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, np.asarray(self.data.Y).flatten())
+
 
 
 

--- a/models/MLmodels/RandomForest.py
+++ b/models/MLmodels/RandomForest.py
@@ -102,16 +102,27 @@ class RandomForest:
 
     def save_the_trained_model(self):
         # save the model to disk
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_RandomForest_model.sav'
-        pickle.dump(self.RandomForestM, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         # save the model to disk
+        self.RandomForestM = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_RandomForest_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
     def get_trained_model(self):
         return self.RandomForestM
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, self.data.Y)
+
+
 
 
 # RandomForest().regression_and_plot_curves()

--- a/models/MLmodels/Ridge.py
+++ b/models/MLmodels/Ridge.py
@@ -100,16 +100,27 @@ class Ridge:
 
     def save_the_trained_model(self):
         # save the model to disk
+        model_trained_on_full_data = self.train_model_without_train_test_split()
         filename = 'finalized_Ridge_model.sav'
-        pickle.dump(self.ridge, open(filename, 'wb'))
+        pickle.dump(model_trained_on_full_data, open(filename, 'wb'))
 
     def save_the_class_included_the_trained_model(self):
         # save the model to disk
+        self.ridge = self.train_model_without_train_test_split()
         filename = 'class_contains_trained_Ridge_model_with_more_functionalities.sav'
         pickle.dump(self, open(filename, 'wb'))
 
     def get_trained_model(self):
         return self.ridge
+
+    def train_model_without_train_test_split(self):
+        """
+        Creates a new instance of the machine learning model,
+        training it on the full data set.
+        """
+        return self.get_pure_model().fit(self.data.X, self.data.Y)
+
+
 
 
 


### PR DESCRIPTION
As the title say. When exporting model to binary, retrain it to use the full dataset and not only the training partition of the dataset.